### PR TITLE
ci: add Conventional Commits

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,12 @@
+name: Conventional Commits
+
+on: [pull_request]
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: webiny/action-conventional-commits@v1.3.0


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce conventional commit messages for pull requests.

* [`.github/workflows/conventional-commits.yml`](diffhunk://#diff-f9885af19817980378f57069d1ab25748e068abca2fd23f7d4e334a642deee8dR1-R12): Added a new workflow named "Conventional Commits" that triggers on pull requests. It uses the `actions/checkout@v4` action and the `webiny/action-conventional-commits@v1.3.0` action to validate commit messages.