### PR TITLE
ci: update PR title linting

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   lint-pr-title:
-    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/conventional-commits.yaml@conventional-commits-v1.0.0
+    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/conventional-commits.yml@conventional-commits-v1.0.0
     secrets:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for linting pull request titles to improve maintainability and align with best practices. The most significant changes include renaming the workflow, modifying the trigger events, and switching to a reusable workflow.

### Workflow updates:

* Renamed the workflow from `Conventional Commits` to `Lint PR Title` for clarity. (`.github/workflows/conventional-commits.yml`, [.github/workflows/conventional-commits.ymlL1-R14](diffhunk://#diff-f9885af19817980378f57069d1ab25748e068abca2fd23f7d4e334a642deee8dL1-R14))
* Updated the trigger events to use `pull_request_target` with specific event types (`opened`, `edited`, `reopened`) instead of a generic `pull_request` event. (`.github/workflows/conventional-commits.yml`, [.github/workflows/conventional-commits.ymlL1-R14](diffhunk://#diff-f9885af19817980378f57069d1ab25748e068abca2fd23f7d4e334a642deee8dL1-R14))
* Replaced the inline job definition with a reusable workflow from `iExecBlockchainComputing` to simplify maintenance and ensure consistency. (`.github/workflows/conventional-commits.yml`, [.github/workflows/conventional-commits.ymlL1-R14](diffhunk://#diff-f9885af19817980378f57069d1ab25748e068abca2fd23f7d4e334a642deee8dL1-R14))