### PR TITLE
ci: fix commit lint

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -9,5 +9,6 @@ on:
 
 jobs:
   lint-pr-title:
-    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/conventional-commits.yml@fix/cc/remove-reserved
-    secrets: inherit
+    permissions:
+      pull-requests: read
+    uses: iExecBlockchainComputing/github-actions-workflows/.github/workflows/conventional-commits.yml@conventional-commits-v1.0.1


### PR DESCRIPTION
This pull request updates the configuration of the `lint-pr-title` job in the `.github/workflows/conventional-commits.yml` file to improve security and use the latest version of the workflow.

Workflow configuration updates:

* Updated the `uses` field to reference version `conventional-commits-v1.0.1` of the workflow, ensuring the job uses the latest version.
* Replaced the `secrets` section with a `permissions` field set to `pull-requests: read`, improving security by limiting access to only the necessary permissions.