### PR TITLE
feat: Restore SafeERC20 use & check for zero addresses in LiquidityUnifier

### DIFF
--- a/src/RLCLiquidityUnifier.sol
+++ b/src/RLCLiquidityUnifier.sol
@@ -3,13 +3,16 @@
 
 pragma solidity ^0.8.22;
 
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {AccessControlDefaultAdminRulesUpgradeable} from
     "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {IERC7802} from "./interfaces/IERC7802.sol";
 
 contract RLCLiquidityUnifier is UUPSUpgradeable, AccessControlDefaultAdminRulesUpgradeable, IERC7802 {
+    using SafeERC20 for IERC20Metadata;
+
     bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
     bytes32 public constant TOKEN_BRIDGE_ROLE = keccak256("TOKEN_BRIDGE_ROLE");
 
@@ -62,7 +65,8 @@ contract RLCLiquidityUnifier is UUPSUpgradeable, AccessControlDefaultAdminRulesU
      * @param value The amount of RLC tokens to unlock and transfer
      */
     function crosschainMint(address to, uint256 value) external override onlyRole(TOKEN_BRIDGE_ROLE) {
-        RLC_TOKEN.transfer(to, value);
+        // Re-entrancy safe because the RLC contract is controlled and does not do external calls.
+        RLC_TOKEN.safeTransfer(to, value);
         emit CrosschainMint(to, value, _msgSender());
     }
 
@@ -91,7 +95,8 @@ contract RLCLiquidityUnifier is UUPSUpgradeable, AccessControlDefaultAdminRulesU
      */
     // slither-disable-next-line arbitrary-send-erc20
     function crosschainBurn(address from, uint256 value) external override onlyRole(TOKEN_BRIDGE_ROLE) {
-        RLC_TOKEN.transferFrom(from, address(this), value);
+        // Re-entrancy safe because the RLC contract is controlled and does not do external calls.
+        RLC_TOKEN.safeTransferFrom(from, address(this), value);
         emit CrosschainBurn(from, value, _msgSender());
     }
 

--- a/src/RLCLiquidityUnifier.sol
+++ b/src/RLCLiquidityUnifier.sol
@@ -72,7 +72,7 @@ contract RLCLiquidityUnifier is UUPSUpgradeable, AccessControlDefaultAdminRulesU
         if (to == address(0)) {
             revert InvalidToAddressForCrosschainMint(address(0));
         }
-        // Re-entrancy safe because the RLC contract is controlled and does not do external calls.
+        // Re-entrancy safe because the RLC contract is controlled and does not make external calls.
         RLC_TOKEN.safeTransfer(to, value);
         emit CrosschainMint(to, value, _msgSender());
     }
@@ -106,7 +106,7 @@ contract RLCLiquidityUnifier is UUPSUpgradeable, AccessControlDefaultAdminRulesU
         if (from == address(0)) {
             revert InvalidFromAddressForCrosschainBurn(address(0));
         }
-        // Re-entrancy safe because the RLC contract is controlled and does not do external calls.
+        // Re-entrancy safe because the RLC contract is controlled and does not make external calls.
         RLC_TOKEN.safeTransferFrom(from, address(this), value);
         emit CrosschainBurn(from, value, _msgSender());
     }

--- a/src/RLCLiquidityUnifier.sol
+++ b/src/RLCLiquidityUnifier.sol
@@ -13,8 +13,8 @@ import {IERC7802} from "./interfaces/IERC7802.sol";
 contract RLCLiquidityUnifier is UUPSUpgradeable, AccessControlDefaultAdminRulesUpgradeable, IERC7802 {
     using SafeERC20 for IERC20Metadata;
 
-    error InvalidToAddressForCrosschainMint(address addr);
-    error InvalidFromAddressForCrosschainBurn(address addr);
+    error ERC7802InvalidToAddress(address addr);
+    error ERC7802InvalidFromAddress(address addr);
 
     bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
     bytes32 public constant TOKEN_BRIDGE_ROLE = keccak256("TOKEN_BRIDGE_ROLE");
@@ -70,7 +70,7 @@ contract RLCLiquidityUnifier is UUPSUpgradeable, AccessControlDefaultAdminRulesU
     function crosschainMint(address to, uint256 value) external override onlyRole(TOKEN_BRIDGE_ROLE) {
         // The RLC contract does not check for zero addresses.
         if (to == address(0)) {
-            revert InvalidToAddressForCrosschainMint(address(0));
+            revert ERC7802InvalidToAddress(address(0));
         }
         // Re-entrancy safe because the RLC contract is controlled and does not make external calls.
         RLC_TOKEN.safeTransfer(to, value);
@@ -104,7 +104,7 @@ contract RLCLiquidityUnifier is UUPSUpgradeable, AccessControlDefaultAdminRulesU
     function crosschainBurn(address from, uint256 value) external override onlyRole(TOKEN_BRIDGE_ROLE) {
         // The RLC contract does not check for zero addresses.
         if (from == address(0)) {
-            revert InvalidFromAddressForCrosschainBurn(address(0));
+            revert ERC7802InvalidFromAddress(address(0));
         }
         // Re-entrancy safe because the RLC contract is controlled and does not make external calls.
         RLC_TOKEN.safeTransferFrom(from, address(this), value);

--- a/test/units/RLCLiquidityUnifier.t.sol
+++ b/test/units/RLCLiquidityUnifier.t.sol
@@ -4,9 +4,9 @@
 pragma solidity ^0.8.22;
 
 import {Test} from "forge-std/Test.sol";
+import {stdError} from "forge-std/StdError.sol";
 import {CreateX} from "@createx/contracts/CreateX.sol";
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
-import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {Deploy as RLCLiquidityUnifierDeployScript} from "../../script/RLCLiquidityUnifier.s.sol";
@@ -35,7 +35,7 @@ contract LiquidityUnifierTest is Test {
     RLCMock private rlcToken;
 
     function setUp() public {
-        rlcToken = new RLCMock("iEx.ec Network Token", "RLC");
+        rlcToken = new RLCMock();
         liquidityUnifier = RLCLiquidityUnifier(
             new RLCLiquidityUnifierDeployScript().deploy(
                 address(rlcToken), admin, upgrader, address(new CreateX()), keccak256("salt")
@@ -209,7 +209,7 @@ contract LiquidityUnifierTest is Test {
 
         // Attempt to mint tokens the zero address.
         rlcToken.transfer(liquidityUnifierAddress, amount);
-        vm.expectRevert(abi.encodeWithSelector(IERC20Errors.ERC20InvalidReceiver.selector, address(0)));
+        vm.expectRevert(abi.encodeWithSelector(RLCLiquidityUnifier.InvalidToAddressForCrosschainMint.selector, address(0)));
         vm.prank(bridge);
         liquidityUnifier.crosschainMint(address(0), amount);
         // Check that no tokens were minted.
@@ -448,9 +448,8 @@ contract LiquidityUnifierTest is Test {
     function test_RevertWhen_BurnFromZeroAddress() public {
         _authorizeBridge(bridge);
         // Attempt to burn tokens from the zero address.
-        // This should revert with ERC20InsufficientAllowance because zero address has no allowance
         vm.expectRevert(
-            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientAllowance.selector, liquidityUnifierAddress, 0, amount)
+            abi.encodeWithSelector(RLCLiquidityUnifier.InvalidFromAddressForCrosschainBurn.selector, address(0))
         );
         vm.prank(bridge);
         liquidityUnifier.crosschainBurn(address(0), amount);
@@ -464,9 +463,7 @@ contract LiquidityUnifierTest is Test {
         _approveLiquidityUnifier(user, amount + 1);
 
         // Attempt to burn more than balance
-        vm.expectRevert(
-            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientBalance.selector, user, amount, amount + 1)
-        );
+        vm.expectRevert(stdError.arithmeticError);
         vm.prank(bridge);
         liquidityUnifier.crosschainBurn(user, amount + 1);
         assertEq(rlcToken.balanceOf(user), amount);
@@ -480,11 +477,7 @@ contract LiquidityUnifierTest is Test {
         _approveLiquidityUnifier(user, amount);
 
         // Attempt to burn more than allowance
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IERC20Errors.ERC20InsufficientAllowance.selector, liquidityUnifierAddress, amount, amount + 1
-            )
-        );
+        vm.expectRevert(stdError.arithmeticError);
         vm.prank(bridge);
         liquidityUnifier.crosschainBurn(user, amount + 1);
         assertEq(rlcToken.balanceOf(user), amount + 1);
@@ -495,9 +488,7 @@ contract LiquidityUnifierTest is Test {
         rlcToken.transfer(user, amount);
 
         // Attempt to burn without user approval
-        vm.expectRevert(
-            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientAllowance.selector, liquidityUnifierAddress, 0, amount)
-        );
+        vm.expectRevert(stdError.arithmeticError);
         vm.prank(bridge);
         liquidityUnifier.crosschainBurn(user, amount);
         assertEq(rlcToken.balanceOf(user), amount);

--- a/test/units/RLCLiquidityUnifier.t.sol
+++ b/test/units/RLCLiquidityUnifier.t.sol
@@ -209,9 +209,7 @@ contract LiquidityUnifierTest is Test {
 
         // Attempt to mint tokens the zero address.
         rlcToken.transfer(liquidityUnifierAddress, amount);
-        vm.expectRevert(
-            abi.encodeWithSelector(RLCLiquidityUnifier.ERC7802InvalidToAddress.selector, address(0))
-        );
+        vm.expectRevert(abi.encodeWithSelector(RLCLiquidityUnifier.ERC7802InvalidToAddress.selector, address(0)));
         vm.prank(bridge);
         liquidityUnifier.crosschainMint(address(0), amount);
         // Check that no tokens were minted.
@@ -450,9 +448,7 @@ contract LiquidityUnifierTest is Test {
     function test_RevertWhen_BurnFromZeroAddress() public {
         _authorizeBridge(bridge);
         // Attempt to burn tokens from the zero address.
-        vm.expectRevert(
-            abi.encodeWithSelector(RLCLiquidityUnifier.ERC7802InvalidFromAddress.selector, address(0))
-        );
+        vm.expectRevert(abi.encodeWithSelector(RLCLiquidityUnifier.ERC7802InvalidFromAddress.selector, address(0)));
         vm.prank(bridge);
         liquidityUnifier.crosschainBurn(address(0), amount);
     }

--- a/test/units/RLCLiquidityUnifier.t.sol
+++ b/test/units/RLCLiquidityUnifier.t.sol
@@ -210,7 +210,7 @@ contract LiquidityUnifierTest is Test {
         // Attempt to mint tokens the zero address.
         rlcToken.transfer(liquidityUnifierAddress, amount);
         vm.expectRevert(
-            abi.encodeWithSelector(RLCLiquidityUnifier.InvalidToAddressForCrosschainMint.selector, address(0))
+            abi.encodeWithSelector(RLCLiquidityUnifier.ERC7802InvalidToAddress.selector, address(0))
         );
         vm.prank(bridge);
         liquidityUnifier.crosschainMint(address(0), amount);
@@ -451,7 +451,7 @@ contract LiquidityUnifierTest is Test {
         _authorizeBridge(bridge);
         // Attempt to burn tokens from the zero address.
         vm.expectRevert(
-            abi.encodeWithSelector(RLCLiquidityUnifier.InvalidFromAddressForCrosschainBurn.selector, address(0))
+            abi.encodeWithSelector(RLCLiquidityUnifier.ERC7802InvalidFromAddress.selector, address(0))
         );
         vm.prank(bridge);
         liquidityUnifier.crosschainBurn(address(0), amount);

--- a/test/units/RLCLiquidityUnifier.t.sol
+++ b/test/units/RLCLiquidityUnifier.t.sol
@@ -209,7 +209,9 @@ contract LiquidityUnifierTest is Test {
 
         // Attempt to mint tokens the zero address.
         rlcToken.transfer(liquidityUnifierAddress, amount);
-        vm.expectRevert(abi.encodeWithSelector(RLCLiquidityUnifier.InvalidToAddressForCrosschainMint.selector, address(0)));
+        vm.expectRevert(
+            abi.encodeWithSelector(RLCLiquidityUnifier.InvalidToAddressForCrosschainMint.selector, address(0))
+        );
         vm.prank(bridge);
         liquidityUnifier.crosschainMint(address(0), amount);
         // Check that no tokens were minted.

--- a/test/units/mocks/RLCMock.sol
+++ b/test/units/mocks/RLCMock.sol
@@ -14,8 +14,8 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  */
 contract RLCMock is IERC20 {
     uint256 public totalSupply;
-    mapping(address => uint) balances;
-    mapping(address => mapping(address => uint)) allowed;
+    mapping(address => uint256) balances;
+    mapping(address => mapping(address => uint256)) allowed;
 
     constructor() {
         totalSupply = 87_000_000 * 10 ** 9; // 87 million tokens with 9 decimals
@@ -43,7 +43,7 @@ contract RLCMock is IERC20 {
     }
 
     // Does not check the spender address.
-    function approve(address spender, uint value) external override returns (bool) {
+    function approve(address spender, uint256 value) external override returns (bool) {
         allowed[msg.sender][spender] = value;
         emit Approval(msg.sender, spender, value);
         return true;
@@ -57,10 +57,7 @@ contract RLCMock is IERC20 {
         return balances[account];
     }
 
-    function allowance(
-        address owner,
-        address spender
-    ) external view override returns (uint256) {
+    function allowance(address owner, address spender) external view override returns (uint256) {
         return allowed[owner][spender];
     }
 }

--- a/test/units/mocks/RLCMock.sol
+++ b/test/units/mocks/RLCMock.sol
@@ -43,7 +43,7 @@ contract RLCMock is IERC20 {
     }
 
     // Does not check the spender address.
-    function approve(address spender, uint256 value) external override returns (bool) {
+    function approve(address spender, uint256 value) external returns (bool) {
         allowed[msg.sender][spender] = value;
         emit Approval(msg.sender, spender, value);
         return true;
@@ -53,11 +53,11 @@ contract RLCMock is IERC20 {
         return 9;
     }
 
-    function balanceOf(address account) external view override returns (uint256) {
+    function balanceOf(address account) external view returns (uint256) {
         return balances[account];
     }
 
-    function allowance(address owner, address spender) external view override returns (uint256) {
+    function allowance(address owner, address spender) external view returns (uint256) {
         return allowed[owner][spender];
     }
 }

--- a/test/units/mocks/RLCMock.sol
+++ b/test/units/mocks/RLCMock.sol
@@ -3,24 +3,64 @@
 
 pragma solidity ^0.8.22;
 
-import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-contract RLCMock is ERC20 {
-    uint256 public constant INITIAL_SUPPLY = 87_000_000 * 10 ** 9; // 87 million tokens with 9 decimals
+/**
+ * Simulates the RLC token behavior for testing purposes.
+ * Cannot directly import the original RLC contract because of solidity version mismatch.
+ * Don't use OZ ERC20 as the implementation differs:
+ * - The RLC does not revert when transferring to the zero address.
+ * - The RLC reverts with arithmetic panic error instead of ERC20InsufficientAllowance (for e.g.).
+ */
+contract RLCMock is IERC20 {
+    uint256 public totalSupply;
+    mapping(address => uint) balances;
+    mapping(address => mapping(address => uint)) allowed;
 
-    constructor(string memory _name, string memory _symbol) ERC20(_name, _symbol) {
-        _mint(msg.sender, INITIAL_SUPPLY);
+    constructor() {
+        totalSupply = 87_000_000 * 10 ** 9; // 87 million tokens with 9 decimals
+        balances[msg.sender] = totalSupply;
     }
 
-    function decimals() public view virtual override returns (uint8) {
+    // Does not check the to address.
+    // Reverts with arithmetic panic error for balance issues.
+    function transfer(address to, uint256 value) external returns (bool) {
+        balances[msg.sender] = balances[msg.sender] - value;
+        balances[to] = balances[to] + value;
+        emit Transfer(msg.sender, to, value);
+        return true;
+    }
+
+    // Does not check the from and to addresses.
+    // Reverts with arithmetic panic error for allowance issues.
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        uint256 _allowance = allowed[from][msg.sender];
+        balances[to] = balances[to] + value;
+        balances[from] = balances[from] - value;
+        allowed[from][msg.sender] = _allowance - value;
+        emit Transfer(from, to, value);
+        return true;
+    }
+
+    // Does not check the spender address.
+    function approve(address spender, uint value) external override returns (bool) {
+        allowed[msg.sender][spender] = value;
+        emit Approval(msg.sender, spender, value);
+        return true;
+    }
+
+    function decimals() public pure returns (uint8) {
         return 9;
     }
 
-    function crosschainMint(address _to, uint256 _amount) public {
-        _mint(_to, _amount);
+    function balanceOf(address account) external view override returns (uint256) {
+        return balances[account];
     }
 
-    function crosschainBurn(address _from, uint256 _amount) public {
-        _burn(_from, _amount);
+    function allowance(
+        address owner,
+        address spender
+    ) external view override returns (uint256) {
+        return allowed[owner][spender];
     }
 }

--- a/test/units/utils/TestUtils.sol
+++ b/test/units/utils/TestUtils.sol
@@ -36,7 +36,7 @@ library TestUtils {
         address createXFactory = address(new CreateX());
 
         // Deploy RLC token mock for L1
-        rlcToken = new RLCMock(name, symbol);
+        rlcToken = new RLCMock();
 
         // salt for createX
         bytes32 salt = keccak256("salt");


### PR DESCRIPTION
Fixes high findings in Slither analysis:
https://github.com/iExecBlockchainComputing/rlc-multichain/pull/50/checks?check_run_id=44701361982